### PR TITLE
Change Site URL for Docs

### DIFF
--- a/docs/Reference/Rest.md
+++ b/docs/Reference/Rest.md
@@ -17,6 +17,6 @@ The default location is `http://localhost:9000/swagger-ui`.
 You can also use tools such as [Postman] or [cURL] to interact with Eth2Signer APIs.
 
 <!-- Links -->
-[Eth2Signer REST API documentation]:https://pegasyseng.github.io/eth2signer/#stable/
+[Eth2Signer REST API documentation]: https://pegasyseng.github.io/web3signer/
 [Postman]: https://www.postman.com/
 [cURL]: https://curl.haxx.se/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 
 # Project information
 site_name: Eth2Signer
-site_url: https://docs.eth2signer.pegasys.tech/en/latest/
+site_url: https://docs.eth2signer.consensys.net/en/latest/
 site_description: Eth2Signer documentation.
 site_author: Eth2Signer community
 copyright: Eth2Signer and its documentation are licensed under Apache 2.0 license

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 
 # Project information
 site_name: Eth2Signer
-site_url: https://docs.eth2signer.consensys.net/en/latest/
+site_url: https://docs.eth2signer.consensys.net/
 site_description: Eth2Signer documentation.
 site_author: Eth2Signer community
 copyright: Eth2Signer and its documentation are licensed under Apache 2.0 license


### PR DESCRIPTION
Changing Site URL to new https://docs.eth2signer.consensys.net/en/latest/

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## Pull Request Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes ES-<Jira issue number> -->
<!-- Example: "fixes ES-1234" -->
