### PR TITLE
Amend git clone command to include submodules

### DIFF
--- a/docs/HowTo/Get-Started/Build-From-Source.md
+++ b/docs/HowTo/Get-Started/Build-From-Source.md
@@ -20,7 +20,7 @@ description: Building Web3Signer from source code
 Clone the `Consensys/web3signer` repository:
 
 ```bash
-git clone https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys/web3signer.git
 ```
 
 ### Build Web3Signer
@@ -63,7 +63,7 @@ bin/web3signer --help
 Clone the `Consensys/web3signer` repository:
 
 ```bat
-git clone https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys/web3signer.git
 ```
 
 ### Build Web3Signer


### PR DESCRIPTION
## Pull request checklist

Use the following list to make sure your PR fits the Web3Signer doc quality standard.

### Before creating the pull request

Make sure that:

- [x] you have read the [contribution guidelines](https://github.com/ConsenSys/doc.common/wiki/Contributing-to-Documentation).
- [x] you have [tested your changes locally](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-documentation-site-locally) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [x] you have fixed all the issues raised by the tests, if any.
- [x] you have verified the rendering of your changes on
  [ReadTheDocs.org PR preview](https://github.com/ConsenSys/doc.common/wiki/MkDocs-And-Custom-Markdown-Guide#preview-the-doc-site-for-your-pr-on-readthedocscom)
  and updated the testing link (see [Testing](#testing)).

## Describe the change

Amend git clone command to include submodules

## Issue fixed

Slashing protection reference tests weren't being cloned which caused a build error:
```
> Task :slashing-protection:referencetests:test

ReferenceTestRunner > executeEachReferenceTestFile() > tech.pegasys.web3signer.slashingprotection.ReferenceTestRunner.initializationError FAILED
    java.lang.IllegalArgumentException at ReferenceTestRunner.java:103
 ```

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

https://pegasys-web3signer--97.com.readthedocs.build/en/97/HowTo/Get-Started/Build-From-Source/ should use `git clone --recursive` to include the submodules