### PR TITLE
Eth renaming

### DIFF
--- a/docs/Concepts/Slashing-Protection.md
+++ b/docs/Concepts/Slashing-Protection.md
@@ -4,7 +4,7 @@ description: Describe how slashing protection works in Web3Signer
 
 # Slashing protection
 
-Slashing refers to penalties that are applied to Ethereum 2.0 validators that sign conflicting
+Slashing refers to penalties that are applied to consensus layer validators that sign conflicting
 blocks or attestations.
 
 Web3Signer provides slashing protection to prevent validators from signing blocks and attestations

--- a/docs/HowTo/Configure-Slashing-Protection.md
+++ b/docs/HowTo/Configure-Slashing-Protection.md
@@ -1,10 +1,10 @@
 ---
-description: Configure Ethereum 2.0 slashing protection
+description: Configure consensus layer slashing protection
 ---
 
-# Configure Ethereum 2.0 slashing protection
+# Configure consensus layer slashing protection
 
-Configure [slashing protection] to prevent Ethereum 2.0 validators from being penalized for signing
+Configure [slashing protection] to prevent consensus layer validators from being penalized for signing
 conflicting blocks or attestations.
 
 Install and manage the PostgreSQL database that stores the validator signing history for
@@ -12,7 +12,7 @@ one or more Web3Signer instances.
 
 !!! note
 
-    Ethereum 2.0 [slashing protection] is enabled by default. You therefore must configure a
+    Consensus layer [slashing protection] is enabled by default. You therefore must configure a
     slashing protection database, or disable slashing protection using the
     [`--slashing-protection-db-enabled`](../Reference/CLI/CLI-Subcommands.md#slashing-protection-enabled)
     command line option.

--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -8,16 +8,16 @@ description: Getting started with Web3Signer
 
 * [Signing key configuration files] to access the required signing keys.
 
-Web3Signer supports the Ethereum 1, Ethereum 2, and Filecoin platforms, so you must specify the
+Web3Signer supports the execution layer (formerly Ethereum 1.0), consensus layer (Ethereum 2.0), and Filecoin platforms, so you must specify the
 signing mode, and the location of the signing key configuration files when starting Web3Signer.
 
-=== "Ethereum 1.0"
+=== "Execution layer"
 
     ```bash
     web3signer --key-store-path=/Users/me/keyFiles/ eth1
     ```
 
-=== "Ethereum 2.0"
+=== "Consensus layer"
 
     ```bash
     web3signer --key-store-path=/Users/me/keyFiles/ eth2 --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
@@ -36,16 +36,16 @@ In the command line:
 * Specify the [subcommand] to indicate which signing mode to use. Valid subcommands are `eth1`,
     `eth2`, and `filecoin`. You can only specify one signing mode when starting Web3Signer.
 
-## Ethereum 2.0 considerations
+## Consensus layer considerations
 
-Ethereum 2.0 [slashing protection] is enabled by default, and you must specify
+Consensus layer [slashing protection] is enabled by default, and you must specify
 the details the [slashing protection database], or disable slashing protection using the
 [`--slashing-protection-db-enabled`](../../Reference/CLI/CLI-Subcommands.md#slashing-protection-enabled)
 command line option.
 
 !!! note
 
-     Web3Signer also allows you to [bulk load Ethereum 2.0 signing keys] stored in Azure Key Vault.
+     Web3Signer also allows you to [bulk load consensus layer signing keys] stored in Azure Key Vault.
 
 Start the client, for example [Teku] by specifying the Web3Signer details.
 
@@ -59,6 +59,6 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
 [Signing key configuration files]: ../Use-Signing-Keys.md
 [Teku]: https://docs.teku.consensys.net/en/latest/HowTo/External-Signer/Use-External-Signer/
 [subcommand]: ../../Reference/CLI/CLI-Subcommands.md
-[bulk load Ethereum 2.0 signing keys]: ../Use-Signing-Keys.md#bulk-loading-ethereum-20-keys
+[bulk load consensus layer signing keys]: ../Use-Signing-Keys.md#bulk-loading-consensus-layer-keys
 [slashing protection]: ../../Concepts/Slashing-Protection.md
 [slashing protection database]: ../../HowTo/Configure-Slashing-Protection.md

--- a/docs/HowTo/Store-Keys-Vaults/Use-Azure.md
+++ b/docs/HowTo/Store-Keys-Vaults/Use-Azure.md
@@ -27,7 +27,7 @@ Web3Signer supports the following authentication modes:
 [Register Web3Signer as an application] and [add a signing key in Azure Key Vault].
 
 Take note of the following to specify when [configuring the signing key configuration file] or [bulk
-loading Ethereum 2.0 signing keys]:
+loading consensus layer signing keys]:
 
 * Vault name, which is part of the URL (for example `https://<vaultname>.vault.azure.net`)
 * Client credentials, which can include:
@@ -43,7 +43,7 @@ loading Ethereum 2.0 signing keys]:
 
 <!-- links -->
 [configuring the signing key configuration file]: ../Use-Signing-Keys.md#using-key-configuration-files
-[bulk loading Ethereum 2.0 signing keys]: ../Use-Signing-Keys.md#bulk-loading-ethereum-20-keys
+[bulk loading consensus layer signing keys]: ../Use-Signing-Keys.md#bulk-loading-consensus-layer-keys
 [Register Web3Signer as an application]: https://docs.microsoft.com/en-us/azure/key-vault/general/authentication
 [add a signing key in Azure Key Vault]: https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault
 [Client secret]: https://docs.microsoft.com/en-us/azure/key-vault/secrets/about-secrets

--- a/docs/HowTo/Use-Signing-Keys.md
+++ b/docs/HowTo/Use-Signing-Keys.md
@@ -19,11 +19,11 @@ You can configure access to the signing key by:
 
 * [Creating a separate key configuration file] for each signing key.
 * Using the [`eth2` subcommand options](../Reference/CLI/CLI-Subcommands.md#eth2) to bulk load
-    Ethereum 2.0 signing keys stored in Azure Key Vault.
+    consensus layer signing keys stored in Azure Key Vault.
 
 !!! note
 
-    Bulk-loading is only available when using the Ethereum 2.0 platform with keys stored in
+    Bulk-loading is only available when using the consensus layer platform with keys stored in
     Azure Key Vault, and can be used in combination with key configuration files.
 
 ## Using key configuration files
@@ -43,9 +43,9 @@ to specify the location of the key configuration files.
     web3signer --key-store-path=/Users/me/keyFiles/ eth2
     ```
 
-## Bulk loading Ethereum 2.0 keys
+## Bulk loading consensus layer keys
 
-You can bulk load Ethereum 2.0 keys that are stored in Azure Key Vault. To do this use the
+You can bulk load consensus layer keys that are stored in Azure Key Vault. To do this use the
 Web3Signer [`eth2` subcommand options](../Reference/CLI/CLI-Subcommands.md#eth2).
 
 !!! example

--- a/docs/Reference/CLI/CLI-Subcommands.md
+++ b/docs/Reference/CLI/CLI-Subcommands.md
@@ -12,6 +12,12 @@ The Web3Signer subcommands are used to specify the platform being used:
 * `web3signer [Options] eth1`
 * `web3signer [Options] filecoin [Filecoin Options]`
 
+!!! note
+
+    The execution layer was formerly called Ethereum 1.0. The consensus layer was formerly called Ethereum 2.0.
+    The subcommands for the execution layer and the consensus layer are still `eth1` and `eth2` respectively.
+    For more information on the name change, refer to the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
+
 ## Specifying subcommand options
 
 The subcommand must be specified on the command line, but the subcommand options can be specified:
@@ -260,7 +266,7 @@ Name of the vault to access. Sub-domain of vault.azure.net.
 
 Predefined network configuration.
 Accepts a predefined network name, or file path or URL to a YAML configuration file. See the
-[Ethereum 2.0 specification] for examples.
+[consensus specification] for examples.
 
 The default is `mainnet`.
 
@@ -271,12 +277,12 @@ The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain   | Type       | Description                                      |
-|:----------|:--------|:-----------|:-------------------------------------------------|
-| `mainnet` | Eth 2.0 | Production | Main network.                                    |
-| `minimal` | Eth 2.0 | Test       | Used for local testing and development networks. |
-| `pyrmont` | Eth 2.0 | Test       | Multi-client testnet.                            |
-| `prater`  | Eth 2.0 | Test       | Multi-client testnet.                            |
+| Network   | Chain           | Type       | Description                                      |
+|:----------|:----------------|:-----------|:-------------------------------------------------|
+| `mainnet` | Consensus layer | Production | Main network.                                    |
+| `minimal` | Consensus layer | Test       | Used for local testing and development networks. |
+| `pyrmont` | Consensus layer | Test       | Multi-client testnet.                            |
+| `prater`  | Consensus layer | Test       | Multi-client testnet.                            |
 
 #### `slashing-protection-db-password`
 
@@ -681,4 +687,4 @@ Predefined network configuration. Accepts a predefined network name. The default
 [include the port number in the database URL]: https://jdbc.postgresql.org/documentation/head/connect.html
 [slashing protection]: ../../Concepts/Slashing-Protection.md
 [validator client interchange format]: https://eips.ethereum.org/EIPS/eip-3076
-[Ethereum 2.0 specification]: https://github.com/ethereum/eth2.0-specs/tree/master/configs
+[consensus specification]: https://github.com/ethereum/consensus-specs/tree/master/configs

--- a/docs/Reference/Rest.md
+++ b/docs/Reference/Rest.md
@@ -22,6 +22,33 @@ The default location is `http://localhost:9000/swagger-ui`.
 
 You can also use tools such as [Postman] or [cURL] to interact with Web3Signer APIs.
 
+## Endpoint example usage
+
+### `/api/v1/eth2/publicKeys`
+
+Returns the ETH2 BLS public keys for the private keys that have been loaded into Web3Signer.
+
+### `/api/v1/eth2/sign/{identifier}`
+
+Signs data for the ETH2 BLS public key specified as part of the URL and returns the signature.
+
+### `/eth/v1/keystores`
+
+Lists all validating public keys known to and decrypted by this keymanager binary
+
+### `/reload`
+
+Reloads signer keys asynchronously.
+This is used after adding new keys to a current set of validators.
+The call reloads the keys and makes Web3signer aware of the change.
+Not used by validator clients
+
+### `/upcheck`
+
+Checks the Web3Signer server status.
+Confirms if Web3Signer is connected and running.
+Not used by validator clients
+
 <!-- Links -->
 [REST API documentation]: https://consensys.github.io/web3signer/
 [Postman]: https://www.postman.com/

--- a/docs/Reference/Rest.md
+++ b/docs/Reference/Rest.md
@@ -22,33 +22,6 @@ The default location is `http://localhost:9000/swagger-ui`.
 
 You can also use tools such as [Postman] or [cURL] to interact with Web3Signer APIs.
 
-## Endpoint example usage
-
-### `/api/v1/eth2/publicKeys`
-
-Returns the ETH2 BLS public keys for the private keys that have been loaded into Web3Signer.
-
-### `/api/v1/eth2/sign/{identifier}`
-
-Signs data for the ETH2 BLS public key specified as part of the URL and returns the signature.
-
-### `/eth/v1/keystores`
-
-Lists all validating public keys known to and decrypted by this keymanager binary
-
-### `/reload`
-
-Reloads signer keys asynchronously.
-This is used after adding new keys to a current set of validators.
-The call reloads the keys and makes Web3signer aware of the change.
-Not used by validator clients
-
-### `/upcheck`
-
-Checks the Web3Signer server status.
-Confirms if Web3Signer is connected and running.
-Not used by validator clients
-
 <!-- Links -->
 [REST API documentation]: https://consensys.github.io/web3signer/
 [Postman]: https://www.postman.com/

--- a/docs/Tutorials/Launchpad-Keystores.md
+++ b/docs/Tutorials/Launchpad-Keystores.md
@@ -1,10 +1,10 @@
 ---
-title: Load keystores generated using the Eth 2.0 Launchpad tool
+title: Load keystores generated using the consensus layer Launchpad tool
 ---
 
 # Load Launchpad keystores
 
-The Launchpad tool is used to create validators that participate in the Ethereum 2.0
+The Staking Launchpad tool is used to create validators that participate in the consensus layer
 proof-of-stake network. The tool generates an encrypted keystore file containing the validator
 details. Load this keystore into Web3Signer to sign attestations and blocks with the validator
 details.
@@ -30,10 +30,10 @@ teku --network=pyrmont --metrics-enabled --rest-api-enabled
 ## 2. Generate validators
 
 This step generates a validator on the `pyrmont` testnet. Use the
-[ETH 2.0 `pyrmont` launchpad](https://pyrmont.launchpad.ethereum.org/) and
+[`pyrmont` staking launchpad](https://pyrmont.launchpad.ethereum.org/) and
 follow the step-by-step process to deposit your funds and generate the keystore.
 
-The process includes installing the ETH 2.0 deposit CLI tool, to generate your validator keystores
+The process includes installing the consensus layer deposit CLI tool, to generate your validator keystores
 locally. Keystores are generated in the `eth2deposit-cli-<version>/validator_keys` folder. In this example
 we generated a keystore named `keystore-m_12381_3600_0_0_0-1606109670.json`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,6 @@ vault, or encrypted on a disk.
 Web3Signer can sign payloads using secp256k1 and BLS12-381 signing keys, and supports the following
 platforms:
 
-* Ethereum 1.0
-* Ethereum 2.0
+* Execution layer (formerly called Ethereum 1.0)
+* Consensus layer (formerly called Ethereum 2.0)
 * [Filecoin](https://filecoin.io/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,7 @@ nav:
     - Concepts:
         - Slashing protection: Concepts/Slashing-Protection.md
     - Tutorials:
-        - Load ETH 2.0 keystores: Tutorials/Launchpad-Keystores.md
+        - Load consensus layer keystores: Tutorials/Launchpad-Keystores.md
     - Reference:
         - Command line:
             - Options: Reference/CLI/CLI-Syntax.md


### PR DESCRIPTION

## Describe the change
Update the Eth1 to "execution layer" and Eth2 to "consensus layer" per the [Ethereum Foundation update](https://blog.ethereum.org/2022/01/24/the-great-eth2-renaming/).
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #106 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://pegasys-web3signer--{your PR number}.org.readthedocs.build/en/{your PR number}/
where {your PR number} must be replaced by the number of this PR (for example, 123).
-->
