### PR TITLE
Add section with example for configuring an eth2 public testnet

### DIFF
--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -13,19 +13,19 @@ description: Getting started with Web3Signer
 
 * [Signing key configuration files] to access the required signing keys.
 
-Web3Signer supports execution layer clients, consensus layer clients, and Filecoin platforms, so you must specify the
+Web3Signer supports consensus layer clients, execution layer clients, and Filecoin platforms, so you must specify the
 signing mode, and the location of the signing key configuration files when starting Web3Signer.
-
-=== "Execution layer client"
-
-    ```bash
-    web3signer --key-store-path=/Users/me/keyFiles/ eth1
-    ```
 
 === "Consensus layer client"
 
     ```bash
     web3signer --key-store-path=/Users/me/keyFiles/ eth2 --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+    ```
+
+=== "Execution layer client"
+
+    ```bash
+    web3signer --key-store-path=/Users/me/keyFiles/ eth1
     ```
 
 === "Filecoin"
@@ -38,8 +38,8 @@ In the command line:
 
 * Use the [`--key-store-path`](../../Reference/CLI/CLI-Syntax.md#key-store-path) option to specify
     the location of the signing key configuration files.
-* Specify the [subcommand] to indicate which signing mode to use. Valid subcommands are `eth1`,
-    `eth2`, and `filecoin`. You can only specify one signing mode when starting Web3Signer.
+* Specify the [subcommand] to indicate which signing mode to use. Valid subcommands are `eth2`, `eth1`,
+    and `filecoin`. You can only specify one signing mode when starting Web3Signer.
 
 ## Consensus layer considerations
 
@@ -59,6 +59,21 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
     If Teku connects to a network other than `mainnet`, then the
     [`--network`](../../Reference/CLI/CLI-Subcommands.md#network) option must be specified, and it
     must match the network used by the Teku client.
+
+### Public testnets
+
+If you are running Web3Signer eth2 mode on a public testnet then you must specify the `network` option.
+It is important that this network matches the one you have setup for your validator client.
+For example, if you have [teku set up to run on goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
+then you must configure Web3Signer with the goerli network under the eth2 subcommand as in the example below.
+
+=== "Example"
+
+    ```bash
+    web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=goerli --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+    ```
+
+See the [`--network` documentation](../../Reference/CLI/CLI-Subcommands.md#network) for more information about this option and the supported networks.
 
 ## Confirm Web3Signer is running
 

--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -63,7 +63,7 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
 ### Public testnets
 
 If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
-It is important that this network matches the one you have setup for your validator client.
+It's important that this network matches the one you set up for your validator client.
 For example, if you have [Teku set up to run on Goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
 then you must configure Web3Signer with the Goerli network under the eth2 subcommand as in the example below.
 

--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -65,7 +65,7 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
 If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
 It's important that this network matches the one you set up for your validator client.
 For example, if you have [Teku set up to run on Goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
-then you must configure Web3Signer with the Goerli network under the eth2 subcommand as in the example below.
+then you must configure Web3Signer with the Goerli network under the `eth2` subcommand, as in the example below.
 
 === "Example"
 

--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -62,7 +62,7 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
 
 ### Public testnets
 
-If you are running Web3Signer eth2 mode on a public testnet then you must specify the `network` option.
+If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
 It is important that this network matches the one you have setup for your validator client.
 For example, if you have [Teku set up to run on Goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
 then you must configure Web3Signer with the Goerli network under the eth2 subcommand as in the example below.

--- a/docs/HowTo/Get-Started/Start-Web3Signer.md
+++ b/docs/HowTo/Get-Started/Start-Web3Signer.md
@@ -64,8 +64,8 @@ Start the client, for example [Teku] by specifying the Web3Signer details.
 
 If you are running Web3Signer eth2 mode on a public testnet then you must specify the `network` option.
 It is important that this network matches the one you have setup for your validator client.
-For example, if you have [teku set up to run on goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
-then you must configure Web3Signer with the goerli network under the eth2 subcommand as in the example below.
+For example, if you have [Teku set up to run on Goerli](https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Connect/Connect-To-Testnet/#sync-the-execution-layer-network)
+then you must configure Web3Signer with the Goerli network under the eth2 subcommand as in the example below.
 
 === "Example"
 


### PR DESCRIPTION
We had two users separately make the same mistake when setting up web3signer on goerli. They missed adding the --network flag to the eth2 subcommand. They both used the Get Started/Start Web3signer page to configure. 

Even though it's mentioned in a note on this page, I have added an additional section to show an example of running with a public testnet (goerli).

Also, I have prioritised the eth2 examples over eth1 further up the page since eth2 is this product's main use case.

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

## After creating your PR and tests have finished

Make sure that:

- [x] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [x] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-web3signer--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->

https://pegasys-web3signer--135.com.readthedocs.build/en/135/HowTo/Get-Started/Start-Web3Signer/