### PR TITLE
fix broken JDBC doc link

### DIFF
--- a/docs/HowTo/Configure-Slashing-Protection.md
+++ b/docs/HowTo/Configure-Slashing-Protection.md
@@ -162,8 +162,8 @@ command line option. The timeout defaults to 3000 milliseconds.
 [Docker]: https://docs.docker.com/install/
 [run the PostgreSQL database in a container]: https://hub.docker.com/_/postgres/
 [Flyway]: https://flywaydb.org/documentation/
-[include the port number in the database URL]: https://jdbc.postgresql.org/documentation/head/connect.html
+[include the port number in the database URL]: https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database
 [Teku]: https://docs.teku.consensys.net/HowTo/External-Signer/Use-External-Signer/
-[connect to the database]: https://jdbc.postgresql.org/documentation/head/connect.html
+[connect to the database]: https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database
 [validator client interchange format]: https://eips.ethereum.org/EIPS/eip-3076
 [HikariCP]: https://github.com/brettwooldridge/HikariCP


### PR DESCRIPTION
# Pull request checklist

Use the following template to make sure your PR fits the Web3Signer documentation standard.

## Before creating the PR

Make sure that:

- [x] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [x] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change

<!-- Add a clear and concise description of what your PR changes in the documentation. -->

replace the JDBC doc link by a new one as the doc changed

## Issue fixed

<!-- Link to the GitHub issue that your PR addresses.

Add "fixes #{your issue number}" to close the issue automatically when the PR is merged.

If your PR doesn't completely fix the issue, add "see #{your issue number}" to link to the issue
without automatically closing it. -->

fixes #137 

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example, lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-web3signer--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->

https://pegasys-web3signer--138.com.readthedocs.build/en/138/HowTo/Configure-Slashing-Protection/