### PR TITLE
Hashicorp key config file httpProtocolVersion

### DIFF
--- a/docs/Reference/key-config-file-params.md
+++ b/docs/Reference/key-config-file-params.md
@@ -81,6 +81,7 @@ token: "s.MuZwBqZ0iE1HzvD64v3HMlhT”
 | **serverPort** | Port of the HashiCorp Vault server. |
 | **timeout** | Timeout in milliseconds for requests to the HashiCorp Vault server. |
 | **token** | The root token displayed by the HashiCorp Vault server. |
+| **httpProtocolVersion** | Override Http protocol version that is used to connect to Hashicorp Vault. Valid values are `HTTP_2` and `HTTP_1_1`. The default is `HTTP_2`. |
 
 ## Azure Key Vault
 

--- a/docs/Reference/key-config-file-params.md
+++ b/docs/Reference/key-config-file-params.md
@@ -81,7 +81,7 @@ token: "s.MuZwBqZ0iE1HzvD64v3HMlhT”
 | **serverPort** | Port of the HashiCorp Vault server. |
 | **timeout** | Timeout in milliseconds for requests to the HashiCorp Vault server. |
 | **token** | The root token displayed by the HashiCorp Vault server. |
-| **httpProtocolVersion** | Override Http protocol version that is used to connect to HashiCorp Vault. Valid values are `HTTP_2` and `HTTP_1_1`. The default is `HTTP_2`. |
+| **httpProtocolVersion** | Override HTTP protocol version that is used to connect to HashiCorp Vault. Valid values are `HTTP_2` and `HTTP_1_1`. The default is `HTTP_2`. |
 
 ## Azure Key Vault
 

--- a/docs/Reference/key-config-file-params.md
+++ b/docs/Reference/key-config-file-params.md
@@ -81,7 +81,7 @@ token: "s.MuZwBqZ0iE1HzvD64v3HMlhT”
 | **serverPort** | Port of the HashiCorp Vault server. |
 | **timeout** | Timeout in milliseconds for requests to the HashiCorp Vault server. |
 | **token** | The root token displayed by the HashiCorp Vault server. |
-| **httpProtocolVersion** | Override Http protocol version that is used to connect to Hashicorp Vault. Valid values are `HTTP_2` and `HTTP_1_1`. The default is `HTTP_2`. |
+| **httpProtocolVersion** | Override Http protocol version that is used to connect to HashiCorp Vault. Valid values are `HTTP_2` and `HTTP_1_1`. The default is `HTTP_2`. |
 
 ## Azure Key Vault
 


### PR DESCRIPTION
Update docs for Hashicorp key config file. Add `httpProtocolVersion`.

See https://github.com/Consensys/web3signer/pull/817