### PR TITLE
Provide missing formatting code for JSON-RPC API page

### DIFF
--- a/docs/Reference/API/json-rpc.md
+++ b/docs/Reference/API/json-rpc.md
@@ -107,8 +107,6 @@ Transaction object:
 
 `result` : `data` - The signed transaction object.
 
-:::info
-
 <!--tabs-->
 
 # curl HTTP request
@@ -128,8 +126,6 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_signTransaction","params":[{
 ```
 
 <!--/tabs-->
-
-:::
 
 ## `eth_sendTransaction`
 

--- a/docs/Reference/API/json-rpc.md
+++ b/docs/Reference/API/json-rpc.md
@@ -157,8 +157,6 @@ Submitting a transaction with the same nonce as a pending transaction and a high
 
 `result` : `data` - 32-byte transaction hash
 
-:::info
-
 <!--tabs-->
 
 # curl HTTP request

--- a/docs/Reference/API/json-rpc.md
+++ b/docs/Reference/API/json-rpc.md
@@ -129,6 +129,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_signTransaction","params":[{
 
 <!--/tabs-->
 
+:::
+
 ## `eth_sendTransaction`
 
 Creates and signs a transaction using the signing key.


### PR DESCRIPTION
Edited Markdown to remove admonitions in the Web3Signer JSON-RPC API page.
 
Fixes #197 

See [https://doc-web3signer-irgjdi7d5-infura-web.vercel.app/Reference/API/json-rpc for incorporated edits.](https://doc-web3signer-git-fork-mjsmike62-197-format-9c8a1e-infura-web.vercel.app/Reference/API/json-rpc)