### PR TITLE
Update Java runtime prerequisite to v17

### DIFF
--- a/docs/get-started/install-binaries.md
+++ b/docs/get-started/install-binaries.md
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 :::caution Important
 
-Web3Signer requires Java 11 or later releases.
+Web3Signer requires Java 17 or later releases.
 
 :::
 


### PR DESCRIPTION
Web3Signer now requires Java 17 or above since [23.8.0](https://github.com/Consensys/web3signer/releases/tag/23.8.0).

> Breaking Changes
> Use Java 17 for build and runtime. Remove Java 11 variant of docker image. zip/tar.gz distributions will require Java 17 or above to run Web3Signer.