### PR TITLE
Doc fields for EIP-1559 txns

### DIFF
--- a/docs/reference/api/json-rpc.md
+++ b/docs/reference/api/json-rpc.md
@@ -99,8 +99,8 @@ Transaction object:
 | `to` | Data, 20&nbsp;bytes | Optional for contract creation | Address of the receiver. `null` if this is a contract creation transaction. |
 | `gas` | Quantity | Optional | Gas provided by the sender. The default is `90000`. |
 | `gasPrice` | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. Used only in non [EIP-1559] transactions. |
-| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [EIP-1559] transactions. |
-| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [EIP-1559] transactions. |
+| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay above the base fee. Used only in [EIP-1559] transactions. |
+| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay. Used only in [EIP-1559] transactions. |
 | `nonce` | Quantity | Optional | Number of transactions made by the sender before this one. Must be specified if using [GoQuorum](https://docs.goquorum.consensys.net/). |
 | `value` | Quantity | Optional | Value transferred in Wei. |
 | `data` | Quantity | Optional | Compiled contract code or hash of the invoked method signature and encoded parameters. |
@@ -145,8 +145,8 @@ Transaction object:
 | `to` | Data, 20&nbsp;bytes | Optional for contract creation | Address of the receiver. `null` if this is a contract creation transaction. |
 | `gas` | Quantity | Optional | Gas provided by the sender. The default is `90000`. |
 | `gasPrice` | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. Used only in non [EIP-1559] transactions. |
-| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [EIP-1559] transactions. |
-| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [EIP-1559] transactions. |
+| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay above the base fee. Used only in [EIP-1559] transactions. |
+| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay. Used only in [EIP-1559] transactions. |
 | `nonce` | Quantity | Optional | Number of transactions made by the sender before this one. Must be specified if using [GoQuorum](https://consensys.net/docs/goquorum/). |
 | `value` | Quantity | Optional | Value transferred in Wei. |
 | `data` | Quantity | Optional | Compiled contract code or hash of the invoked method signature and encoded parameters. |

--- a/docs/reference/api/json-rpc.md
+++ b/docs/reference/api/json-rpc.md
@@ -98,7 +98,9 @@ Transaction object:
 | `from` | Data, 20&nbsp;bytes | Required | Address of the sender. |
 | `to` | Data, 20&nbsp;bytes | Optional for contract creation | Address of the receiver. `null` if this is a contract creation transaction. |
 | `gas` | Quantity | Optional | Gas provided by the sender. The default is `90000`. |
-| `gasPrice` | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. |
+| `gasPrice` | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. Used only in non [EIP-1559] transactions. |
+| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [EIP-1559] transactions. |
+| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [EIP-1559] transactions. |
 | `nonce` | Quantity | Optional | Number of transactions made by the sender before this one. Must be specified if using [GoQuorum](https://docs.goquorum.consensys.net/). |
 | `value` | Quantity | Optional | Value transferred in Wei. |
 | `data` | Quantity | Optional | Compiled contract code or hash of the invoked method signature and encoded parameters. |
@@ -139,13 +141,15 @@ Transaction object:
 
 | Key | Type | Required/Optional | Value |
 | --- | :-- | --- | --- |
-| **from** | Data, 20&nbsp;bytes | Required | Address of the sender. |
-| **to** | Data, 20&nbsp;bytes | Optional for contract creation | Address of the receiver. `null` if this is a contract creation transaction. |
-| **gas** | Quantity | Optional | Gas provided by the sender. The default is `90000`. |
-| **gasPrice** | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. |
-| **nonce** | Quantity | Optional | Number of transactions made by the sender before this one. Must be specified if using [GoQuorum](https://consensys.net/docs/goquorum/). |
-| **value** | Quantity | Optional | Value transferred in Wei. |
-| **data** | Quantity | Optional | Compiled contract code or hash of the invoked method signature and encoded parameters. |
+| `from` | Data, 20&nbsp;bytes | Required | Address of the sender. |
+| `to` | Data, 20&nbsp;bytes | Optional for contract creation | Address of the receiver. `null` if this is a contract creation transaction. |
+| `gas` | Quantity | Optional | Gas provided by the sender. The default is `90000`. |
+| `gasPrice` | Quantity | Optional | Gas price provided by the sender in Wei. The default is `0`. Used only in non [EIP-1559] transactions. |
+| `maxPriorityFeePerGas` | Quantity | Optional | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [EIP-1559] transactions. |
+| `maxFeePerGas` | Quantity | Optional | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [EIP-1559] transactions. |
+| `nonce` | Quantity | Optional | Number of transactions made by the sender before this one. Must be specified if using [GoQuorum](https://consensys.net/docs/goquorum/). |
+| `value` | Quantity | Optional | Value transferred in Wei. |
+| `data` | Quantity | Optional | Compiled contract code or hash of the invoked method signature and encoded parameters. |
 
 :::tip
 
@@ -176,3 +180,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{
 ```
 
 <!--/tabs-->
+
+<!--links-->
+
+[EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559


### PR DESCRIPTION
Add `maxPriorityFeePerGas` and `maxFeePerGas` fields to `eth_sendTransaction` and `eth_signTransaction` parameter descriptions.

preview: https://doc-web3signer-git-196-eip-1559-infura-web.vercel.app/reference/api/json-rpc#eth_signtransaction

fixes #196 