### PR TITLE
Fix eth2 mode network config file example

### DIFF
--- a/docs/reference/cli/subcommands.md
+++ b/docs/reference/cli/subcommands.md
@@ -1538,7 +1538,7 @@ WEB3SIGNER_ETH2_NETWORK=mainnet
 # Configuration file
 
 ```bash
-network: "mainnet"
+eth2.network: "mainnet"
 ```
 
 <!--/tabs-->


### PR DESCRIPTION
The eth2 network config file must be `eth2.network`.

Fixes https://github.com/Consensys/web3signer/issues/521


