### PR TITLE
Added tables to make available options clearer

### DIFF
--- a/docs/how-to/load-keys.md
+++ b/docs/how-to/load-keys.md
@@ -8,24 +8,24 @@ import TabItem from '@theme/TabItem';
 
 # Load signing keys
 
-Load signing keys using a [key configuration file], or bulk loading with the [`eth1` and `eth2` subcommands]. 
+Load signing keys using a [key configuration file], or bulk load using the [`eth1` and `eth2` subcommands]. 
 Web3Signer supports loading keys with the following methods: 
 
-| Key storage                          | Key configuration file | Bulk loading with `eth1` subcommand | Bulk loading with `eth2` subcommand | 
-|--------------------------------------|:----------------------:|:-----------------------------------:|:-----------------------------------:|
-| [Keystore files]                     |           x            |                  x                  |                  x                  | 
+| Key storage                          | Key configuration file | Bulk load with `eth1` | Bulk load with `eth2` | 
+|--------------------------------------|:----------------------:|:---------------------:|:---------------------:|
+| [Keystore files]                     |           x            |           x           |           x           | 
 | **Vaults**                           | 
-| [Hashicorp Vault]                    |           x            |                                     |                                     | 
-| [Azure Key Vault]                    |           x            |                  x                  |                  x                  | 
-| [AWS Secrets Manager]                |           x            |                                     |                  x                  | 
-| [AWS KMS]                            |           x            |                  x                  |                                     | 
-| [GCP Secret Manager]                 |                        |                                     |                  x                  | 
+| [Hashicorp Vault]                    |           x            |                       |                       | 
+| [Azure Key Vault]                    |           x            |           x           |           x           | 
+| [AWS Secrets Manager]                |           x            |                       |           x           | 
+| [AWS KMS]                            |           x            |           x           |                       | 
+| [GCP Secret Manager]                 |                        |                       |           x           | 
 | **Hardware Security Modules (HSMs)** |           
-| [USB Armory Mk II]                   |           x            |                                     |                                     |
-| [YubiHSM 2]                          |           x            |                                     |                                     |
+| [USB Armory Mk II]                   |           x            |                       |                       |
+| [YubiHSM 2]                          |           x            |                       |                       |
 
 :::note
-Bulk loading can be used in combination with key configuration files.
+You can bulk load in combination with using key configuration files.
 :::
 
 ## Use key configuration files

--- a/docs/how-to/load-keys.md
+++ b/docs/how-to/load-keys.md
@@ -19,7 +19,7 @@ Web3Signer supports loading keys with the following methods:
 | [Azure Key Vault]                    |           x            |                  x                  |                  x                  | 
 | [AWS Secrets Manager]                |           x            |                                     |                  x                  | 
 | [AWS KMS]                            |           x            |                  x                  |                                     | 
-| [GCP Secret Manager]                 |           ?            |                                     |                  x                  | 
+| [GCP Secret Manager]                 |                        |                                     |                  x                  | 
 | **Hardware Security Modules (HSMs)** |           
 | [USB Armory Mk II]                   |           x            |                                     |                                     |
 | [YubiHSM 2]                          |           x            |                                     |                                     |
@@ -158,6 +158,7 @@ keystore passwords.
 [AWS Secrets Manager]: #aws-secrets-manager
 [keystore files]: #keystore-files
 [AWS KMS]: #aws-key-management-service
+[GCP Secret Manager]: #gcp-secret-manager
 [keystore files]: #keystore-files
 [Hashicorp Vault]: #use-key-configuration-files
 [USB Armory Mk II]: #use-key-configuration-files

--- a/docs/how-to/load-keys.md
+++ b/docs/how-to/load-keys.md
@@ -8,19 +8,24 @@ import TabItem from '@theme/TabItem';
 
 # Load signing keys
 
-You can load signing keys by:
+Load signing keys using a [key configuration file], or bulk loading with the [`eth1` and `eth2` subcommands]. 
+Web3Signer supports loading keys with the following methods: 
 
-- [Creating a key configuration file]. Key configuration files can be used to load all types of signing keys supported by Web3Signer.
-- Using the [`eth2` subcommand options](../reference/cli/subcommands.md#eth2) to bulk load consensus
-  layer signing keys stored in [Azure Key Vault](#azure-key-vault), [AWS Secrets Manager](#aws-secrets-manager),
-  or [keystore files](#keystore-files).
-- Using the [`eth1` subcommand options](../reference/cli/subcommands.md#eth1) to bulk load execution
-  layer signing keys stored in [Azure Key Vault](#azure-key-vault), [AWS Key Management Service (KMS)](#bulk-load-keys)
-  or [keystore files](#keystore-files).
+| Key storage                          | Key configuration file | Bulk loading with `eth1` subcommand | Bulk loading with `eth2` subcommand | 
+|--------------------------------------|:----------------------:|:-----------------------------------:|:-----------------------------------:|
+| [Keystore files]                     |           x            |                  x                  |                  x                  | 
+| **Vaults**                           | 
+| [Hashicorp Vault]                    |           x            |                                     |                                     | 
+| [Azure Key Vault]                    |           x            |                  x                  |                  x                  | 
+| [AWS Secrets Manager]                |           x            |                                     |                  x                  | 
+| [AWS KMS]                            |           x            |                  x                  |                                     | 
+| [GCP Secret Manager]                 |           ?            |                                     |                  x                  | 
+| **Hardware Security Modules (HSMs)** |           
+| [USB Armory Mk II]                   |           x            |                                     |                                     |
+| [YubiHSM 2]                          |           x            |                                     |                                     |
 
 :::note
-Bulk loading is only available when using keys stored in Azure Key Vault, AWS Secrets Manager or KMS,
-or keystore files, and can be used in combination with key configuration files.
+Bulk loading can be used in combination with key configuration files.
 :::
 
 ## Use key configuration files
@@ -46,6 +51,14 @@ web3signer --key-store-path=/Users/me/keyFiles/ eth2
 You can bulk load keys that are stored in Azure Key Vault using the Web3Signer
 [`eth1` subcommand options](../reference/cli/subcommands.md#eth1) or
 [`eth2` subcommand options](../reference/cli/subcommands.md#eth2).
+
+For `eth1` bulk loading, Web3Signer creates Azure keys connections in bulk mode. The Azure keys
+connections are used to perform remote signing using SECP keys. Web3Signer does not download the private keys for `eth1` bulk loading with Azure.
+
+For `eth2` bulk loading, Web3Signer bulk loads the BLS keys from Azure Secrets. The bulk loading
+mode supports loading multiple consensus layer keys from the same Azure secret, if keys are stored with a line terminating character such as `\n`.
+This saves cost when dealing with a large number of keys.
+Up to 200 keys can be stored under a secret name.
 
 <Tabs>
 
@@ -131,3 +144,12 @@ keystore passwords.
 
 [key configuration file]: ../reference/key-config-file-params.md
 [Creating a key configuration file]: #use-key-configuration-files
+[`eth1` and `eth2` subcommands]: ../reference/cli/subcommands.md
+[Azure Key Vault]: #azure-key-vault
+[AWS Secrets Manager]: #aws-secrets-manager
+[keystore files]: #keystore-files
+[AWS KMS]: #aws-key-management-service
+[keystore files]: #keystore-files
+[Hashicorp Vault]: #use-key-configuration-files
+[USB Armory Mk II]: #use-key-configuration-files
+[YubiHSM 2]: #use-key-configuration-files

--- a/docs/how-to/store-keys/index.md
+++ b/docs/how-to/store-keys/index.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Store signing keys
 
-Web3Signer supports BLS12-381 or secp256k1 signing keys stored in:
+Web3Signer supports BLS12-381 or secp256k1 signing keys stored in the following ways:
 
 | Key storage                          | SECP256K1 | BLS |
 |--------------------------------------|:---------:|:---:|

--- a/docs/how-to/store-keys/index.md
+++ b/docs/how-to/store-keys/index.md
@@ -19,7 +19,7 @@ Web3Signer supports BLS12-381 or secp256k1 signing keys stored in:
 | [Azure Key Vault]                    |     x     |  x  | 
 | [AWS Secrets Manager]                |           |  x  | 
 | [AWS KMS]                            |     x     |     | 
-| GCP Secret Manager                   |           |  x  |
+| [GCP Secret Manager]                 |           |  x  |
 | **Hardware Security Modules (HSMs)** |           |     |
 | [YubiHSM 2]                          |     x     |  x  |
 | [USB Armory Mk II]                   |     x     |  x  |
@@ -33,6 +33,7 @@ After storing keys, [load keys into Web3Signer](../load-keys.md).
 [Azure Key Vault]: vaults/azure.md
 [AWS Secrets Manager]: vaults/aws/secrets-manager-consensus-layer.md
 [AWS KMS]: vaults/aws/kms-execution-layer.md
+[GCP Secret Manager]: vaults/gcp.md
 [YubiHSM 2]: hsm/yubihsm2.md
 [USB Armory Mk II]: hsm/usb-armory.md
 

--- a/docs/how-to/store-keys/index.md
+++ b/docs/how-to/store-keys/index.md
@@ -10,14 +10,30 @@ import TabItem from '@theme/TabItem';
 
 Web3Signer supports BLS12-381 or secp256k1 signing keys stored in:
 
-- Raw unencrypted files
-- [Keystore files](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2335.md)
-- Vaults:
-  - [HashiCorp Vault](vaults/hashicorp.md)
-  - [Azure Key Vault](vaults/azure.md)
-  - [AWS Secrets Manager](vaults/aws/secrets-manager-consensus-layer.md)
-- Hardware Security Modules (HSMs):
-  - [YubiHSM 2](hsm/yubihsm2.md)
-  - [USB Armory Mk II](hsm/usb-armory.md)
+| Key storage                          | SECP256K1 | BLS |
+|--------------------------------------|:---------:|:---:|
+| Raw files                            |     x     |  x  |
+| [Keystore files]                     |     x     |  x  | 
+| **Vaults**                           |
+| [Hashicorp Vault]                    |     x     |  x  | 
+| [Azure Key Vault]                    |     x     |  x  | 
+| [AWS Secrets Manager]                |           |  x  | 
+| [AWS KMS]                            |     x     |     | 
+| GCP Secret Manager                   |           |  x  |
+| **Hardware Security Modules (HSMs)** |           |     |
+| [YubiHSM 2]                          |     x     |  x  |
+| [USB Armory Mk II]                   |     x     |  x  |
 
 After storing keys, [load keys into Web3Signer](../load-keys.md).
+
+<!-- links -->
+
+[Keystore files]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2335.md
+[HashiCorp Vault]: vaults/hashicorp.md
+[Azure Key Vault]: vaults/azure.md
+[AWS Secrets Manager]: vaults/aws/secrets-manager-consensus-layer.md
+[AWS KMS]: vaults/aws/kms-execution-layer.md
+[YubiHSM 2]: hsm/yubihsm2.md
+[USB Armory Mk II]: hsm/usb-armory.md
+
+


### PR DESCRIPTION
Also fixes #184

Pushing as a draft because this needs the GCP PR to be merged first so I can add the relevant links. 

@usmansaleem - is the point about 200 keys being able to be stored under a secret also true for Azure eth2 mode?  I copied it over from the AWS newline explanation. 