### PR TITLE
261 deprec goerli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-debug.log*
 yarn-error.log*
 .vercel
 .yarn/*
+yarn.lock

--- a/docs/get-started/start-web3signer.md
+++ b/docs/get-started/start-web3signer.md
@@ -71,12 +71,12 @@ the network used by the Teku client.
 If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
 It's important that this network matches the one you set up for your validator client.
 For example, if you have [Teku set up to run on
-Sepolia](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
-then you must configure Web3Signer with the Sepolia network under the `eth2` subcommand, as in the
+Holesky](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
+then you must configure Web3Signer with the Holesky network under the `eth2` subcommand, as in the
 following example.
 
 ```bash
-web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=sepolia --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=holesky --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
 ```
 
 See the [`--network` documentation](../reference/cli/subcommands.md#network) for more information

--- a/docs/get-started/start-web3signer.md
+++ b/docs/get-started/start-web3signer.md
@@ -71,12 +71,12 @@ the network used by the Teku client.
 If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
 It's important that this network matches the one you set up for your validator client.
 For example, if you have [Teku set up to run on
-Goerli](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
-then you must configure Web3Signer with the Goerli network under the `eth2` subcommand, as in the
+Sepolia](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
+then you must configure Web3Signer with the Sepolia network under the `eth2` subcommand, as in the
 following example.
 
 ```bash
-web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=goerli --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=sepolia --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
 ```
 
 See the [`--network` documentation](../reference/cli/subcommands.md#network) for more information

--- a/docs/reference/cli/subcommands.md
+++ b/docs/reference/cli/subcommands.md
@@ -2320,7 +2320,7 @@ Possible values are:
 | :--------- | :--------------- | :--------- | :----------------------------------------------- |
 | `mainnet`  | Consensus layer  | Production | Ethereum main network.                           |
 | `minimal`  | Consensus layer  | Test       | Used for local testing and development networks. |
-| `goerli`   | Consensus layer  | Test       | Multi-client testnet.                            |
+| `sepolia`   | Consensus layer  | Test       | Multi-client testnet.                            |
 | `holesky`  | Consensus layer  | Test       | Multi-client testnet.                            |
 | `lukso`    | Consensus layer  | Production | Lukso main network.                              |
 | `gnosis`   | Consensus layer  | Production | Gnosis main network.                             |

--- a/docs/reference/cli/subcommands.md
+++ b/docs/reference/cli/subcommands.md
@@ -2320,7 +2320,7 @@ Possible values are:
 | :--------- | :--------------- | :--------- | :----------------------------------------------- |
 | `mainnet`  | Consensus layer  | Production | Ethereum main network.                           |
 | `minimal`  | Consensus layer  | Test       | Used for local testing and development networks. |
-| `sepolia`   | Consensus layer  | Test       | Multi-client testnet.                            |
+| `sepolia`  | Consensus layer  | Test       | Multi-client [permissioned](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg) testnet.|
 | `holesky`  | Consensus layer  | Test       | Multi-client testnet.                            |
 | `lukso`    | Consensus layer  | Production | Lukso main network.                              |
 | `gnosis`   | Consensus layer  | Production | Gnosis main network.                             |

--- a/docs/tutorials/load-launchpad-keystores.md
+++ b/docs/tutorials/load-launchpad-keystores.md
@@ -10,7 +10,7 @@ The Staking Launchpad tool is used to create validators that participate in the 
 proof-of-stake network. The tool generates an encrypted keystore file containing the validator details.
 Load this keystore into Web3Signer to sign attestations and blocks with the validator details.
 
-This tutorial uses Teku and Web3Signer to run validators created on the `goerli` testnet.
+This tutorial uses Teku and Web3Signer to run validators created on the `sepolia` testnet.
 
 **Prerequisites**:
 
@@ -24,13 +24,13 @@ Sync the Teku beacon chain node before submitting your deposit to avoid incurrin
 penalties if the validator is unable to perform its duties when the deposit is processed and activated.
 
 ```bash
-teku --network=goerli --metrics-enabled --rest-api-enabled
+teku --network=sepolia --metrics-enabled --rest-api-enabled
 ```
 
 ## 2. Generate validators
 
-This step generates a validator on the `goerli` testnet.
-Use the [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/) and follow the
+This step generates a validator on the `sepolia` testnet.
+Use the [Holeksy Staking Launchpad](https://holesky.launchpad.ethereum.org/en/) and follow the
 step-by-step process to deposit your funds and generate the keystore.
 
 The process includes installing the consensus layer deposit CLI tool, to generate your validator
@@ -80,7 +80,7 @@ You can use any naming format, but it must have the `.yaml` extension.
 Start Web3Signer and specify the location of the key configuration files and [slashing protection database].
 
 ```bash
-web3signer --key-store-path=/Users/me/keys eth2 --network=goerli --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+web3signer --key-store-path=/Users/me/keys eth2 --network=holesky --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
 ```
 
 :::note
@@ -95,7 +95,7 @@ Start Teku and specify the public keys of the validators that Web3Signer signs a
 blocks for, and specify the Web3Signer address.
 
 ```bash
-teku --network=goerli \
+teku --network=holesky \
 --eth1-endpoint=http://localhost:8545 \
 --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b \
 --validators-external-signer-url=http://localhost:9000

--- a/docs/tutorials/load-launchpad-keystores.md
+++ b/docs/tutorials/load-launchpad-keystores.md
@@ -10,7 +10,7 @@ The Staking Launchpad tool is used to create validators that participate in the 
 proof-of-stake network. The tool generates an encrypted keystore file containing the validator details.
 Load this keystore into Web3Signer to sign attestations and blocks with the validator details.
 
-This tutorial uses Teku and Web3Signer to run validators created on the `sepolia` testnet.
+This tutorial uses Teku and Web3Signer to run validators created on the `holesky` testnet.
 
 **Prerequisites**:
 
@@ -24,12 +24,12 @@ Sync the Teku beacon chain node before submitting your deposit to avoid incurrin
 penalties if the validator is unable to perform its duties when the deposit is processed and activated.
 
 ```bash
-teku --network=sepolia --metrics-enabled --rest-api-enabled
+teku --network=holesky --metrics-enabled --rest-api-enabled
 ```
 
 ## 2. Generate validators
 
-This step generates a validator on the `sepolia` testnet.
+This step generates a validator on the `holesky` testnet.
 Use the [Holeksy Staking Launchpad](https://holesky.launchpad.ethereum.org/en/) and follow the
 step-by-step process to deposit your funds and generate the keystore.
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -154,6 +154,7 @@ hideable
 hikari
 hola
 holesky
+Holeksy
 horiz
 hostman
 hostnames
@@ -289,6 +290,7 @@ paularmstrong
 pbcopy
 pcss
 peaceiris
+permissioned
 petstore
 philpl
 photoshop

--- a/versioned_docs/version-24.6.0/get-started/start-web3signer.md
+++ b/versioned_docs/version-24.6.0/get-started/start-web3signer.md
@@ -71,12 +71,12 @@ the network used by the Teku client.
 If you are running Web3Signer `eth2` mode on a public testnet, then you must specify the `network` option.
 It's important that this network matches the one you set up for your validator client.
 For example, if you have [Teku set up to run on
-Goerli](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
-then you must configure Web3Signer with the Goerli network under the `eth2` subcommand, as in the
+Holesky](https://docs.teku.consensys.net/get-started/connect/testnet#sync-the-execution-layer-network)
+then you must configure Web3Signer with the Holesky network under the `eth2` subcommand, as in the
 following example.
 
 ```bash
-web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=goerli --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+web3signer --key-store-path=/Users/me/keyFiles/ eth2 --network=holesky --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
 ```
 
 See the [`--network` documentation](../reference/cli/subcommands.md#network) for more information

--- a/versioned_docs/version-24.6.0/reference/cli/subcommands.md
+++ b/versioned_docs/version-24.6.0/reference/cli/subcommands.md
@@ -2320,7 +2320,7 @@ Possible values are:
 | :--------- | :--------------- | :--------- | :----------------------------------------------- |
 | `mainnet`  | Consensus layer  | Production | Ethereum main network.                           |
 | `minimal`  | Consensus layer  | Test       | Used for local testing and development networks. |
-| `goerli`   | Consensus layer  | Test       | Multi-client testnet.                            |
+| `sepolia`  | Consensus layer  | Test       | Multi-client testnet.                            |
 | `holesky`  | Consensus layer  | Test       | Multi-client testnet.                            |
 | `lukso`    | Consensus layer  | Production | Lukso main network.                              |
 | `gnosis`   | Consensus layer  | Production | Gnosis main network.                             |

--- a/versioned_docs/version-24.6.0/tutorials/load-launchpad-keystores.md
+++ b/versioned_docs/version-24.6.0/tutorials/load-launchpad-keystores.md
@@ -10,7 +10,7 @@ The Staking Launchpad tool is used to create validators that participate in the 
 proof-of-stake network. The tool generates an encrypted keystore file containing the validator details.
 Load this keystore into Web3Signer to sign attestations and blocks with the validator details.
 
-This tutorial uses Teku and Web3Signer to run validators created on the `goerli` testnet.
+This tutorial uses Teku and Web3Signer to run validators created on the `holesky` testnet.
 
 **Prerequisites**:
 
@@ -24,13 +24,13 @@ Sync the Teku beacon chain node before submitting your deposit to avoid incurrin
 penalties if the validator is unable to perform its duties when the deposit is processed and activated.
 
 ```bash
-teku --network=goerli --metrics-enabled --rest-api-enabled
+teku --network=holesky --metrics-enabled --rest-api-enabled
 ```
 
 ## 2. Generate validators
 
-This step generates a validator on the `goerli` testnet.
-Use the [Goerli Staking Launchpad](https://goerli.launchpad.ethereum.org/) and follow the
+This step generates a validator on the `holesky` testnet.
+Use the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/en/) and follow the
 step-by-step process to deposit your funds and generate the keystore.
 
 The process includes installing the consensus layer deposit CLI tool, to generate your validator
@@ -80,7 +80,7 @@ You can use any naming format, but it must have the `.yaml` extension.
 Start Web3Signer and specify the location of the key configuration files and [slashing protection database].
 
 ```bash
-web3signer --key-store-path=/Users/me/keys eth2 --network=goerli --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
+web3signer --key-store-path=/Users/me/keys eth2 --network=holesky --slashing-protection-db-url="jdbc:postgresql://localhost/web3signer" --slashing-protection-db-username=postgres --slashing-protection-db-password=password
 ```
 
 :::note
@@ -95,7 +95,7 @@ Start Teku and specify the public keys of the validators that Web3Signer signs a
 blocks for, and specify the Web3Signer address.
 
 ```bash
-teku --network=goerli \
+teku --network=holesky \
 --eth1-endpoint=http://localhost:8545 \
 --validators-external-signer-public-keys=0xa99a...e44c,0xb89b...4a0b \
 --validators-external-signer-url=http://localhost:9000


### PR DESCRIPTION
Fixes #261 
Goerli testnet deprecation reflected in these docs

Sepolia is a permissioned launchpad, hence why focus is placed on Holesky https://holesky.launchpad.ethereum.org/en/