### PR TITLE
update theme componenet path

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -10,7 +10,8 @@ import {
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import {
   useDocsPreferredVersion,
-} from '@docusaurus/theme-common/internal';
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
 function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
   return (
     <Translate
@@ -111,7 +112,7 @@ function DocVersionBannerEnabled({className, versionMetadata}) {
   );
 }
 export default function DocVersionBanner({className}) {
-  const versionMetadata = useDocsPreferredVersion();
+  const versionMetadata = useDocsVersion();
   if (versionMetadata.banner) {
     return (
       <DocVersionBannerEnabled


### PR DESCRIPTION
Hi @bgravenorst @alexandratran this is similar to doc.teku. where it looks like a path has been updated. I pulled the component out and changed to docsPreferredVersion - not sure if this PR is needed or not

3.5.2 of docusaurus builds as is without these fixes but if we need `docsVersion` we likely need this fix in 