### PR TITLE
log4j: replace status with level

### DIFF
--- a/docs/how-to/monitor/logging.md
+++ b/docs/how-to/monitor/logging.md
@@ -24,7 +24,7 @@ You can provide your own logging configuration using the standard Log4J2 configu
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">INFO</Property>
     <Property name="dependency.log.level">INFO</Property>


### PR DESCRIPTION
 The attribute status has been deprecated in log4j since log4j version 2.24.0. Reference: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status
