### PR TITLE
add renovatebot

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,0 +1,23 @@
+name: renovatebot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  renovatebot-check:
+    runs-on: ubuntu-24.04
+    environment: security
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run renovatebot
+        uses: ConsenSys/github-actions/renovatebot@0dbddeeb180c249e624dc1681c67f22325daedd5 # main
+        with:
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
+          GH_REPOSITORY: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "description": "1. Pin all GitHub Actions to sha256 digests by default",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
+      "description": "2. For trusted actions, allow updates",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/**",
+        "consensys/github-actions/**"
+      ],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds dependency automation via Renovate and a GitHub Actions workflow, without changing application/runtime code.
> 
> **Overview**
> Adds a `renovatebot` GitHub Actions workflow that runs on `main` when workflow files change (or via manual dispatch) and executes Renovate using GitHub App credentials from secrets.
> 
> Introduces `renovate.json` extending `config:recommended`, disables the dependency dashboard, and enables digest pinning rules for `github-actions` (including `actions/**` and `consensys/github-actions/**`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08bcd97ea57fdf019ae8c7bb257637e773a5fd9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->