### PR TITLE
Document structured logging options

### DIFF
--- a/docs/how-to/monitor/logging.md
+++ b/docs/how-to/monitor/logging.md
@@ -20,8 +20,8 @@ This option changes the volume of events displayed in the log.
 Valid log levels are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
 The default level is `INFO`.
 
-Use the [`--logging-format`](../../reference/cli/options.md#logging-format) option to select a structured JSON output format.
-Structured logging emits each log record as a JSON object in a well-defined format, making logs consistent and machine-readable.
+Use the [`--logging-format`](../../reference/cli/options.md#logging-format) option to specify the logging format.
+You can select a structured logging format, which emits each log record as a JSON object in a well-defined format, making logs consistent and machine-readable.
 Valid formats are `PLAIN`, `ECS`, `GCP`, `LOGSTASH`, `GELF`.
 The default format is `PLAIN`, which specifies traditional pattern-based text logging.
 
@@ -143,3 +143,7 @@ setting it before starting Web3Signer.
 ```bash title="Set the custom logging and start Web3Signer"
 JAVA_OPTS="-Dlog4j.configurationFile=/Users/me/debug.xml" web3signer --key-store-path=/Users/me/keyFiles/ eth2
 ```
+
+:::info Note
+When a custom Log4j2 configuration file is provided, it takes precedence over the [logging command line options](#basic-log-level-setting).
+:::

--- a/docs/how-to/monitor/logging.md
+++ b/docs/how-to/monitor/logging.md
@@ -20,7 +20,7 @@ This option changes the volume of events displayed in the log.
 Valid log levels are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
 The default level is `INFO`.
 
-Use the [`--logging-format`](../../reference/cli/options.md#logging-format) option to select a structured JSON output format. 
+Use the [`--logging-format`](../../reference/cli/options.md#logging-format) option to select a structured JSON output format.
 Structured logging emits each log record as a JSON object in a well-defined format, making logs consistent and machine-readable.
 Valid formats are `PLAIN`, `ECS`, `GCP`, `LOGSTASH`, `GELF`.
 The default format is `PLAIN`, which specifies traditional pattern-based text logging.
@@ -32,8 +32,10 @@ You can provide your own logging configuration using the standard Log4J2 configu
 Web3Signer includes the Log4J JSON Template Layout library, which enables production-ready templates for each structured logging format.
 Specify `JsonTemplateLayout` in your configuration file to use the Log4J templates.
 
-The following is an example of a custom configuration file, a configuration file using the default Elastic Common Schema (ECS) template, and a configuration file using the Google Cloud Platform (GCP) template.
-For more information, see the Log4j [configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html) and [event templates](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-templates) documentation.
+The following is an example of a custom configuration file, a configuration file using the default Elastic Common Schema (ECS) template,
+and a configuration file using the Google Cloud Platform (GCP) template.
+For more information, see the Log4j [configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html) and
+[event templates](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-templates) documentation.
 
 <Tabs>
 <TabItem value="Custom configuration">

--- a/docs/how-to/monitor/logging.md
+++ b/docs/how-to/monitor/logging.md
@@ -3,24 +3,40 @@ description: Configure Web3Signer's log level settings and log formatting.
 sidebar_position: 2
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Configure logging
 
-Web3Signer provides two methods to configure logging:
+Web3Signer provides multiple methods to configure logging:
 
-- [Basic](#basic-log-level-setting) - changes the log level.
-- [Advanced](#advanced-custom-logging) - configures the output and format of the logs.
+- [Basic](#basic-log-level-setting) - Change the log level or structured logging format.
+- [Advanced](#advanced-custom-logging) - Configure the output and format of the logs.
 
 ## Basic log level setting
 
 Use the [`--logging`](../../reference/cli/options.md#logging) command line option to specify logging verbosity.
-The [`--logging`](../../reference/cli/options.md#logging) option changes the volume of events
-displayed in the log.
+This option changes the volume of events displayed in the log.
 Valid log levels are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
 The default level is `INFO`.
+
+Use the [`--logging-format`](../../reference/cli/options.md#logging-format) option to select a structured JSON output format. 
+Structured logging emits each log record as a JSON object in a well-defined format, making logs consistent and machine-readable.
+Valid formats are `PLAIN`, `ECS`, `GCP`, `LOGSTASH`, `GELF`.
+The default format is `PLAIN`, which specifies traditional pattern-based text logging.
 
 ## Advanced custom logging
 
 You can provide your own logging configuration using the standard Log4J2 configuration mechanisms.
+
+Web3Signer includes the Log4J JSON Template Layout library, which enables production-ready templates for each structured logging format.
+Specify `JsonTemplateLayout` in your configuration file to use the Log4J templates.
+
+The following is an example of a custom configuration file, a configuration file using the default Elastic Common Schema (ECS) template, and a configuration file using the Google Cloud Platform (GCP) template.
+For more information, see the Log4j [configuration file](https://logging.apache.org/log4j/2.x/manual/configuration.html) and [event templates](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-templates) documentation.
+
+<Tabs>
+<TabItem value="Custom configuration">
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -63,15 +79,61 @@ You can provide your own logging configuration using the standard Log4J2 configu
 </Configuration>
 ```
 
+</TabItem>
+<TabItem value="With default ECS template">
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration level="INFO">
+  <Properties>
+    <Property name="root.log.level">INFO</Property>
+  </Properties>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <JsonTemplateLayout/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="${sys:root.log.level}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+</TabItem>
+<TabItem value="With GCP template">
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration level="INFO">
+  <Properties>
+    <Property name="root.log.level">INFO</Property>
+  </Properties>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <JsonTemplateLayout eventTemplateUri="classpath:GcpLayout.json"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="${sys:root.log.level}">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>
+```
+
+</TabItem>
+</Tabs>
+
 To use your custom configuration, set the environment variable `JAVA_OPTS` to the location of your
 configuration file.
 
 ```bash
 export JAVA_OPTS="-Dlog4j.configurationFile=<path_to_file>"
 ```
-
-The above is an example, you can tune your requirements and create your own
-[log4j2 configuration](https://logging.apache.org/log4j/2.x/manual/configuration.html).
 
 For Bash-based executions, you can set the variable for only the scope of the program execution by
 setting it before starting Web3Signer.

--- a/docs/reference/cli/options.md
+++ b/docs/reference/cli/options.md
@@ -407,6 +407,52 @@ idle-connection-timeout-seconds: 60
 Number of seconds to wait before terminating an idle connection.
 The default is 30.
 
+### `logging-format`
+
+<Tabs>
+
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--logging-format=<FORMAT>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--logging-format=ECS
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+WEB3SIGNER_LOGGING_FORMAT=ECS
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+logging-format: "ECS"
+```
+
+  </TabItem>
+</Tabs>
+
+Structured logging format.
+Possible values are:
+
+- `PLAIN` (default) - Traditional pattern-based console logging
+- `ECS` - Elastic Common Schema JSON format
+- `GCP` - Google Cloud Platform JSON format
+- `LOGSTASH` - Logstash JSON Event Layout V1
+- `GELF` - Graylog Extended Log Format
+
+This enables users to select the format without requiring custom Log4j2 configuration files.
+This is useful in containerized and cloud environments where injecting configuration files is cumbersome.
+
 ### `metrics-enabled`
 
 <Tabs>

--- a/docs/reference/cli/options.md
+++ b/docs/reference/cli/options.md
@@ -129,120 +129,6 @@ data-path: "/Users/me/my_node/data"
 
 Directory in which to store temporary files.
 
-### `key-config-path`, `key-store-path`
-
-<Tabs>
-
-  <TabItem value="Syntax" label="Syntax" default>
-
-```bash
---key-config-path=<PATH>
-```
-
-  </TabItem>
-  <TabItem value="Example" label="Example" >
-
-```bash
---key-config-path=/Users/me/keys
-```
-
-  </TabItem>
-  <TabItem value="Environment variable" label="Environment variable" >
-
-```bash
-WEB3SIGNER_KEY_CONFIG_PATH=/Users/me/keys
-```
-
-  </TabItem>
-  <TabItem value="Configuration file" label="Configuration file" >
-
-```bash
-key-config-path: "/Users/me/keys"
-```
-
-  </TabItem>
-</Tabs>
-
-Path to the directory containing the [YAML files required to access keys].
-
-### `key-store-config-file-max-size`
-
-<Tabs>
-
-  <TabItem value="Syntax" label="Syntax" default>
-
-```bash
---key-store-config-file-max-size=<INTEGER>
-```
-
-  </TabItem>
-  <TabItem value="Example" label="Example" >
-
-```bash
---key-store-config-file-max-size=158000000
-```
-
-  </TabItem>
-  <TabItem value="Environment variable" label="Environment variable" >
-
-```bash
-WEB3SIGNER_KEY_STORE_CONFIG_FILE_MAX_SIZE=158000000
-```
-
-  </TabItem>
-  <TabItem value="Configuration file" label="Configuration file" >
-
-```bash
-key-store-config-file-max-size: 158000000
-```
-
-  </TabItem>
-</Tabs>
-
-The maximum signing key configuration file size in bytes.
-This is useful when you're loading a large number of
-[signing key configurations from a single file](../key-config-file-params.md)
-
-The default size is 104857600 bytes (100 MB).
-
-### `logging`
-
-<Tabs>
-
-  <TabItem value="Syntax" label="Syntax" default>
-
-```bash
--l, --logging=<LEVEL>
-```
-
-  </TabItem>
-  <TabItem value="Example" label="Example" >
-
-```bash
---logging=DEBUG
-```
-
-  </TabItem>
-  <TabItem value="Environment variable" label="Environment variable" >
-
-```bash
-WEB3SIGNER_LOGGING=DEBUG
-```
-
-  </TabItem>
-  <TabItem value="Configuration file" label="Configuration file" >
-
-```bash
-logging: "DEBUG"
-```
-
-  </TabItem>
-</Tabs>
-
-Sets logging verbosity.
-Log levels are `OFF`, `FATAL`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
-The default is `INFO`.
-
 ### `http-cors-origins`
 
 <Tabs>
@@ -444,6 +330,120 @@ idle-connection-timeout-seconds: 60
 Number of seconds to wait before terminating an idle connection.
 The default is 30.
 
+### `key-config-path`, `key-store-path`
+
+<Tabs>
+
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--key-config-path=<PATH>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--key-config-path=/Users/me/keys
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+WEB3SIGNER_KEY_CONFIG_PATH=/Users/me/keys
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+key-config-path: "/Users/me/keys"
+```
+
+  </TabItem>
+</Tabs>
+
+Path to the directory containing the [YAML files required to access keys].
+
+### `key-store-config-file-max-size`
+
+<Tabs>
+
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--key-store-config-file-max-size=<INTEGER>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--key-store-config-file-max-size=158000000
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+WEB3SIGNER_KEY_STORE_CONFIG_FILE_MAX_SIZE=158000000
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+key-store-config-file-max-size: 158000000
+```
+
+  </TabItem>
+</Tabs>
+
+The maximum signing key configuration file size in bytes.
+This is useful when you're loading a large number of
+[signing key configurations from a single file](../key-config-file-params.md)
+
+The default size is 104857600 bytes (100 MB).
+
+### `logging`
+
+<Tabs>
+
+  <TabItem value="Syntax" label="Syntax" default>
+
+```bash
+-l, --logging=<LEVEL>
+```
+
+  </TabItem>
+  <TabItem value="Example" label="Example" >
+
+```bash
+--logging=DEBUG
+```
+
+  </TabItem>
+  <TabItem value="Environment variable" label="Environment variable" >
+
+```bash
+WEB3SIGNER_LOGGING=DEBUG
+```
+
+  </TabItem>
+  <TabItem value="Configuration file" label="Configuration file" >
+
+```bash
+logging: "DEBUG"
+```
+
+  </TabItem>
+</Tabs>
+
+Logging verbosity level.
+Possible values are `OFF`, `FATAL`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
+The default is `INFO`.
+
 ### `logging-format`
 
 <Tabs>
@@ -478,7 +478,8 @@ logging-format: "ECS"
   </TabItem>
 </Tabs>
 
-Structured logging format.
+Logging format.
+This option includes standard JSON structured logging formats.
 Possible values are:
 
 - `PLAIN` (default) - Traditional pattern-based console logging


### PR DESCRIPTION
Document how to select structured logging via the `--logging-format` option or the Log4J JSON Template Layout Library. Also fix slight ordering issues on the CLI reference page.

Preview: https://doc-web3signer-nqtf4vhfa-consensys-ddffed67.vercel.app/development/how-to/monitor/logging

Fixes #356 
Fixes #355


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that clarify CLI logging configuration; no runtime or API behavior is modified.
> 
> **Overview**
> Documents structured logging configuration by adding the `--logging-format` CLI option (including supported formats like `ECS`, `GCP`, `LOGSTASH`, `GELF`) and explaining how it differs from log level configuration.
> 
> Updates the logging how-to with tabbed Log4j2 examples using `JsonTemplateLayout` (default template and GCP template), and notes that a custom Log4j2 config overrides CLI logging options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662d8b9881983f703ea0282f0a8ffeac0dd254d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->