### PR TITLE
doc: Update commands in build from source

### DIFF
--- a/docs/get-started/build-from-source.md
+++ b/docs/get-started/build-from-source.md
@@ -39,7 +39,7 @@ cd web3signer
 Build Web3Signer with the Gradle wrapper `gradlew`:
 
 ```bash
-./gradlew build
+./gradlew distTar
 ```
 
 Go to the distribution directory:
@@ -82,7 +82,7 @@ cd web3signer
 Build Web3Signer with the Gradle wrapper `gradlew`:
 
 ```bat
-./gradlew build
+./gradlew distZip
 ```
 
 :::note

--- a/versioned_docs/version-26.4.2/get-started/build-from-source.md
+++ b/versioned_docs/version-26.4.2/get-started/build-from-source.md
@@ -39,7 +39,7 @@ cd web3signer
 Build Web3Signer with the Gradle wrapper `gradlew`:
 
 ```bash
-./gradlew build
+./gradlew distTar
 ```
 
 Go to the distribution directory:
@@ -82,7 +82,7 @@ cd web3signer
 Build Web3Signer with the Gradle wrapper `gradlew`:
 
 ```bat
-./gradlew build
+./gradlew distZip
 ```
 
 :::note


### PR DESCRIPTION
Use `distTar` and `distZip` which bypasses running tests and create platform specific distribution (i.e. .tar.gz and .zip).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates build commands; no runtime or production code is modified.
> 
> **Overview**
> Updates the *Build from source* documentation (current and `version-26.4.2`) to run `./gradlew distTar` on Unix/macOS and `./gradlew distZip` on Windows instead of `./gradlew build`, aligning the instructions with generating platform-specific distribution archives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613e28e44e6568bf5f4b25ab699ee9964e203d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->